### PR TITLE
FIX: fixed href path of css stylesheet in index.html file

### DIFF
--- a/templates/js/index.html
+++ b/templates/js/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Your Generated Front-end</title>
-    <link rel="stylesheet" href="/stylesheets/style.css" />
+    <link rel="stylesheet" href="/css/style.css" />
   </head>
 
   <body>

--- a/templates/js/index.html
+++ b/templates/js/index.html
@@ -1,7 +1,7 @@
 <html>
   <head>
     <title>Your Generated Front-end</title>
-    <link rel="stylesheet" href="/css/style.css" />
+    <link rel="stylesheet" href="/stylesheets/style.css" />
   </head>
 
   <body>


### PR DESCRIPTION
The generated index.html has a link to a CSS stylesheet at "/stylesheets/style.css" but the /stylesheets directory doesn't appear to exist. The styles aren't being applied the index.html either. Changing the path to "/css/style.css" fixes this problem.